### PR TITLE
Add Flask-CORS project

### DIFF
--- a/projects/flask-cors/EXTENSION_STATUS
+++ b/projects/flask-cors/EXTENSION_STATUS
@@ -1,0 +1,2 @@
+Approved: no
+Approval-Date:

--- a/projects/flask-cors/META
+++ b/projects/flask-cors/META
@@ -1,0 +1,8 @@
+Name: Flask-Cors
+Website: https://github.com/corydolphin/flask-cors
+Github: corydolphin/flask-cors
+Bugtracker: https://github.com/corydolphin/flask-cors/issues
+Documentation: http://flask-cors.readthedocs.org/en/latest/
+PyPI: Flask-CORS
+License: MIT
+Status: active

--- a/projects/flask-cors/PROJECT_LEAD
+++ b/projects/flask-cors/PROJECT_LEAD
@@ -1,0 +1,4 @@
+Name: Cory Dolphin
+Github: CoryDolphin
+Twitter: @CoryDolphin
+Email: CoryDolphin@gmail.com

--- a/projects/flask-cors/README
+++ b/projects/flask-cors/README
@@ -1,0 +1,3 @@
+Flask-CORS
+
+Flask-Cors is an extension which adds handling of Cross Origin Resource Sharing (CORS), making cross-origin AJAX easy.


### PR DESCRIPTION
Would love to get this up on the [extension registry](http://flask.pocoo.org/extensions/). Users have requested it be listed there.

Secondly, what are the necessary steps to make this an "approved" extension? I believe I have followed all guidelines and would welcome a review.