### PR TITLE
Add Flask-Rest-JSONAPI project to extensions

### DIFF
--- a/projects/flask-rest-jsonapi/EXTENSION_STATUS
+++ b/projects/flask-rest-jsonapi/EXTENSION_STATUS
@@ -1,0 +1,2 @@
+Approved: no
+Approval-Date:

--- a/projects/flask-rest-jsonapi/META
+++ b/projects/flask-rest-jsonapi/META
@@ -1,0 +1,8 @@
+Name: Flask-Rest-JSONAPI
+Website: https://github.com/miLibris/flask-rest-jsonapi
+Github: miLibris/flask-rest-jsonapi
+Bugtracker: https://github.com/miLibris/flask-rest-jsonapi/issues
+Documentation: http://flask-rest-jsonapi.readthedocs.io/en/latest/
+PyPI: Flask-Rest-JSONAPI
+License: MIT
+Status: active

--- a/projects/flask-rest-jsonapi/PROJECT_LEAD
+++ b/projects/flask-rest-jsonapi/PROJECT_LEAD
@@ -1,0 +1,3 @@
+Name: Pierre CHAISY
+Github: akira-dev
+Email: pierre.chaisy@gmail.com

--- a/projects/flask-rest-jsonapi/README
+++ b/projects/flask-rest-jsonapi/README
@@ -1,0 +1,4 @@
+Flask-Rest-JSONAPI
+
+Flask extension to create web api according to jsonapi specification with
+Flask, Marshmallow and data provider of your choice (SQLAlchemy, MongoDB, ...)


### PR DESCRIPTION
Hello,

i have created a flask extension: https://github.com/miLibris/flask-rest-jsonapi and i would like to know how to register it in the flask entension list.

This extention follows the jsonapi.org protocol and combines the flexibility of Flask-RESTful and the quick usage of Flask-Restless with a data layer concept that allow you to use any ORM or storage provider.

I have made this library because in real life project you want a framework to quickly create simple resource api and also a hudge flexibility to customize the resource. Moreover you ofter need to retrieve data from different data providers so the data layer system provides a way to interface them with a CRUD concept.